### PR TITLE
購入機能実装に向けたカート機能の表示改善

### DIFF
--- a/app/assets/javascripts/carts.coffee
+++ b/app/assets/javascripts/carts.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/modules/_carts.scss
+++ b/app/assets/stylesheets/modules/_carts.scss
@@ -46,7 +46,42 @@
         margin-left: 30px;
       }
     }
-
   }
 }
 
+.cart__footer {
+  width: 700px;
+  border-top: solid 1px gray;
+  margin: 0 auto;
+  padding-bottom: 100px;
+  &__total{
+    display: flex;
+    justify-content: space-evenly;  
+    &--text {
+      padding: 40px 20px 0;
+      font-size: 20px;
+      font-weight: bold;
+      font-family: "YuGothic";
+    }
+    &--price {
+      padding: 40px 20px 0;
+      font-size: 20px;
+      font-weight: bold;
+    }
+  }
+  &__link {
+    width: 130px;
+    background-color: rgb(100, 100, 100);
+    border-radius: 5px;
+    height: 40px;
+    width: 200px;
+    text-align: center;
+    margin: 20px auto 20px;
+    padding-top: 5px;
+    &--text {
+      text-decoration: none;
+      color: white;
+      font-size: 20px;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_masks.scss
+++ b/app/assets/stylesheets/modules/_masks.scss
@@ -37,11 +37,14 @@
       justify-content: flex-end;
       &--name {
         color: white;
-        width: 100px;
+        width: 400px;
         line-height: 50px;
         font-size: 16px;
         text-decoration: none;
         margin-right: 20px;
+        & p {
+          text-align: right
+        }
       }
       &--cart {
         color: white;
@@ -306,6 +309,12 @@
       }
       &--btn {
         margin-left: 5px;
+        width: 130px;
+        background-color: rgb(100, 100, 100);
+        border-radius: 5px;
+        color: white;
+        border-style: none;
+        height: 30px;
       }
     }
     &__caution {

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -4,35 +4,24 @@ class CartsController < ApplicationController
   before_action :setup_cart_item!, only: [:update_item, :delete_item]
 
   def index
-    @products   = []
-    @products_carts  = []
-
+    @user_carts  = []
     carts = Cart.all.order("created_at DESC")
-
-      carts.each do |cart|
-        # 中間テーブルからquantityの値を取り出し、配列(@quantitys)に代入
-        cart.cart_items.each do |c|
-          products_cart = {}
-          products_cart[:quantity] = c.quantity
-          products_cart[:cart_id] = c.cart_id
-          products_cart[:user_id] = c.user_id
-          @products_carts << products_cart
-        end
-
-        # カート情報に合うmasksテーブルのデータを配列(@products)に代入
-        mask = cart.masks
-        mask.each do |m|
-          product = {}
-          product[:name]  = m[:name]
-          product[:image] = m[:image]
-          product[:price] = m[:price]
-          @products << product
-        end
-                
+    carts.each do |cart|
+      cart.masks.zip(cart.cart_items).each do |m, c|
+        user_cart = {}
+        user_cart[:name]  = m[:name]
+        user_cart[:image] = m[:image]
+        user_cart[:price] = m[:price]
+        user_cart[:quantity] = c.quantity
+        user_cart[:cart_id] = c.cart_id
+        user_cart[:user_id] = c.user_id
+        @user_carts << user_cart
       end
+    end
+    @user_carts = uniq_merge(@user_carts, [:name, :user_id], [:quantity])
   end
-  
-  # 商品一覧画面から、「カートへ入れる」を押した時のアクション
+
+  # 商品一覧画面から「カートへ入れる」を押した時のアクション
   def add_item
     if @cart_item.blank?
       @cart_item = current_cart.cart_items.build(mask_id: params[:id])
@@ -43,13 +32,13 @@ class CartsController < ApplicationController
     redirect_to carts_path
   end
 
-  # カート詳細画面から、「変更」を押した時のアクション
+  # カート詳細画面から「変更」を押した時のアクション
   def update_item
     @cart_item.update(quantity: params[:number].to_i)
     redirect_to carts_path
   end
 
-  # カート詳細画面から、「削除」を押した時のアクション
+  # カート詳細画面から「削除」を押した時のアクション
   def delete_item
     @cart = Cart.find(params[:id])
     @cart_item.destroy
@@ -58,7 +47,7 @@ class CartsController < ApplicationController
   end
 
   private
-    # 送られてきたidから現在のカートの中身を@cart_itemと定義
+    # 送られてきたidから現在のカートの中身を@cart_itemと定義するメソッド
     def set_cart_item!
       @cart_item = current_cart.cart_items.find_by(mask_id: params[:id])
     end
@@ -66,4 +55,13 @@ class CartsController < ApplicationController
     def setup_cart_item!
       @cart_item = cart_info.cart_items.find_by(cart_id: params[:id])
     end 
+
+    # 重複データを処理するメソッド
+    def uniq_merge(ary, keys = [], values = [])
+      ary.group_by { |i| keys.map { |key| i[key] } }
+         .map { |k, v|
+           v[1..-1].each { |x| values.each { |y| v[0][y] += x[y] } }
+           v[0]
+         }
+    end
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -5,6 +5,7 @@ class CartsController < ApplicationController
 
   def index
     @user_carts  = []
+    @total_price = 0
     carts = Cart.all.order("created_at DESC")
     carts.each do |cart|
       cart.masks.zip(cart.cart_items).each do |m, c|
@@ -15,10 +16,12 @@ class CartsController < ApplicationController
         user_cart[:quantity] = c.quantity
         user_cart[:cart_id] = c.cart_id
         user_cart[:user_id] = c.user_id
+        user_cart[:total_price] = user_cart[:price] * user_cart[:quantity]
         @user_carts << user_cart
+        @total_price += user_cart[:total_price]
       end
     end
-    @user_carts = uniq_merge(@user_carts, [:name, :user_id], [:quantity])
+    # @user_carts = uniq_merge(@user_carts, [:name, :user_id], [:quantity])
   end
 
   # 商品一覧画面から「カートへ入れる」を押した時のアクション
@@ -57,11 +60,11 @@ class CartsController < ApplicationController
     end 
 
     # 重複データを処理するメソッド
-    def uniq_merge(ary, keys = [], values = [])
-      ary.group_by { |i| keys.map { |key| i[key] } }
-         .map { |k, v|
-           v[1..-1].each { |x| values.each { |y| v[0][y] += x[y] } }
-           v[0]
-         }
-    end
+    # def uniq_merge(ary, keys = [], values = [])
+    #   ary.group_by { |i| keys.map { |key| i[key] } }
+    #      .map { |k, v|
+    #        v[1..-1].each { |x| values.each { |y| v[0][y] += x[y] } }
+    #        v[0]
+    #      }
+    # end
 end

--- a/app/controllers/masks_controller.rb
+++ b/app/controllers/masks_controller.rb
@@ -1,16 +1,17 @@
 class MasksController < ApplicationController
+  before_action :set_header, only: [:index, :show]
+
   def index
-    @tiger   = Mask.find_by(id: 1)
-    @lion    = Mask.find_by(id: 2)
-    @cheetah = Mask.find_by(id: 3)
-    @cat     = Mask.find_by(id: 4)
   end
 
   def show
+    @mask = Mask.find(params[:id])
+  end
+
+  def set_header
     @tiger   = Mask.find_by(id: 1)
     @lion    = Mask.find_by(id: 2)
     @cheetah = Mask.find_by(id: 3)
     @cat     = Mask.find_by(id: 4)
-    @mask = Mask.find(params[:id])
   end
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,5 +1,5 @@
 class CartItem < ApplicationRecord
   belongs_to :mask
-  belongs_to :cart
+  belongs_to :cart, dependent: :destroy
   belongs_to :user
 end

--- a/app/views/carts/_index_cart.html.haml
+++ b/app/views/carts/_index_cart.html.haml
@@ -1,16 +1,16 @@
 
 .cart__main
   %p.cart__main--text CART 
-  -@products.zip(@products_carts).each do |product, products_cart|
-    - if current_user.id == products_cart[:user_id]
+  - @user_carts.each do |user_cart|
+    - if current_user.id == user_cart[:user_id]
       .cart__main__content
         .cart__main__content__left
-          .cart__main__content__left--name #{product[:name]}
-          = image_tag "#{product[:image]}",size: "100x100", class: '.cart__main__content__right--image'
+          .cart__main__content__left--name #{user_cart[:name]}
+          = image_tag "#{user_cart[:image]}",size: "100x100", class: '.cart__main__content__right--image'
         .cart__main__content__right
-          .cart__main__content__right--price ¥#{product[:price]}(税別)
+          .cart__main__content__right--price ¥#{user_cart[:price]}(税別)
           %form.cart__main__content__right--form{action: update_item_path, method: "post"}
-            %input.cart__main__content__right--form-hidden{type: "hidden", name: "id", value: "#{products_cart[:cart_id]}"}
-            %input.cart__main__content__right--form-number{name: "number", placeholder: "#{products_cart[:quantity]}", type: "number", value: "#{products_cart[:quantity]}"}
+            %input.cart__main__content__right--form-hidden{type: "hidden", name: "id", value: "#{user_cart[:cart_id]}"}
+            %input.cart__main__content__right--form-number{name: "number", placeholder: "#{user_cart[:quantity]}", type: "number", value: "#{user_cart[:quantity]}", min: 1}
             %input.cart__main__content__right--form-btn{type: "submit", value: "変更"}
-          = link_to '削除', delete_item_path(id: "#{products_cart[:cart_id]}"),class: 'cart__main__content__right--delete', method: :delete
+          = link_to '削除', delete_item_path(id: "#{user_cart[:cart_id]}"),class: 'cart__main__content__right--delete', method: :delete

--- a/app/views/carts/_index_cart.html.haml
+++ b/app/views/carts/_index_cart.html.haml
@@ -1,16 +1,26 @@
-
-.cart__main
-  %p.cart__main--text CART 
-  - @user_carts.each do |user_cart|
-    - if current_user.id == user_cart[:user_id]
-      .cart__main__content
-        .cart__main__content__left
-          .cart__main__content__left--name #{user_cart[:name]}
-          = image_tag "#{user_cart[:image]}",size: "100x100", class: '.cart__main__content__right--image'
-        .cart__main__content__right
-          .cart__main__content__right--price ¥#{user_cart[:price]}(税別)
-          %form.cart__main__content__right--form{action: update_item_path, method: "post"}
-            %input.cart__main__content__right--form-hidden{type: "hidden", name: "id", value: "#{user_cart[:cart_id]}"}
-            %input.cart__main__content__right--form-number{name: "number", placeholder: "#{user_cart[:quantity]}", type: "number", value: "#{user_cart[:quantity]}", min: 1}
-            %input.cart__main__content__right--form-btn{type: "submit", value: "変更"}
-          = link_to '削除', delete_item_path(id: "#{user_cart[:cart_id]}"),class: 'cart__main__content__right--delete', method: :delete
+.cart
+  .cart__main
+    %p.cart__main--text CART 
+    - @user_carts.each do |user_cart|
+      - if current_user.id == user_cart[:user_id]
+        .cart__main__content
+          .cart__main__content__left
+            .cart__main__content__left--name #{user_cart[:name]}
+            = image_tag "#{user_cart[:image]}",size: "100x100", class: '.cart__main__content__right--image'
+          .cart__main__content__right
+            .cart__main__content__right--price ¥#{user_cart[:price]}(税込)
+            %form.cart__main__content__right--form{action: update_item_path, method: "post"}
+              %input.cart__main__content__right--form-hidden{type: "hidden", name: "id", value: "#{user_cart[:cart_id]}"}
+              %input.cart__main__content__right--form-number{name: "number", placeholder: "#{user_cart[:quantity]}", type: "number", value: "#{user_cart[:quantity]}", min: 1}
+              %input.cart__main__content__right--form-btn{type: "submit", value: "変更"}
+            = link_to '削除', delete_item_path(id: "#{user_cart[:cart_id]}"),class: 'cart__main__content__right--delete', method: :delete
+  .cart__footer
+    .cart__footer__total
+      %p.cart__footer__total--price
+        %span.cart__footer__total--text 合計金額
+        ¥#{@total_price}
+      %p.cart__footer__total--price
+        %span.cart__footer__total--text 寄付金額
+        ¥#{@total_price/10}
+    .cart__footer__link
+      = link_to "購入画面に進む", "#", class: "cart__footer__link--text"

--- a/app/views/masks/_show_content.html.haml
+++ b/app/views/masks/_show_content.html.haml
@@ -8,7 +8,7 @@
   = image_tag @mask.image,size: "300x300", class: 'mask__image'
 
   .mask__buy
-    .mask__buy__price ¥#{@mask.price}(税別)
+    .mask__buy__price ¥#{@mask.price}(税込)
     - if user_signed_in?
       %form.mask__buy__form{action: add_item_path, method: "post"}
         %input.mask__buy__form--hidden{type: "hidden", name: "user_id", value: current_user.id}

--- a/app/views/masks/_show_content.html.haml
+++ b/app/views/masks/_show_content.html.haml
@@ -13,7 +13,7 @@
       %form.mask__buy__form{action: add_item_path, method: "post"}
         %input.mask__buy__form--hidden{type: "hidden", name: "user_id", value: current_user.id}
         %input.mask__buy__form--hidden{type: "hidden", name: "id", value: "#{@mask.id}"}
-        %input.mask__buy__form--number{name: "number", placeholder: "個数", type: "number", value: ""}
+        %input.mask__buy__form--number{name: "number", placeholder: "個数", type: "number", value: "", min: 1}
         %input.mask__buy__form--btn{type: "submit", value: "カートへ入れる"}
     - else
       .mask__buy__caution 購入にはログインが必要です。

--- a/db/migrate/20200414045347_create_cart_items.rb
+++ b/db/migrate/20200414045347_create_cart_items.rb
@@ -4,7 +4,7 @@ class CreateCartItems < ActiveRecord::Migration[5.0]
       t.integer :quantity, default: 0
       t.references :mask, foreign_key: true
       t.references :cart, foreign_key: true
-
+      t.integer  :user_id
       t.timestamps
     end
   end

--- a/db/migrate/20200420083627_add_user_id_to_cart_items.rb
+++ b/db/migrate/20200420083627_add_user_id_to_cart_items.rb
@@ -1,5 +1,0 @@
-class AddUserIdToCartItems < ActiveRecord::Migration[5.0]
-  def change
-    add_column :cart_items, :user_id, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200420083627) do
+ActiveRecord::Schema.define(version: 20200420054238) do
 
   create_table "cart_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "quantity",   default: 0
     t.integer  "mask_id"
     t.integer  "cart_id"
+    t.integer  "user_id"
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
-    t.integer  "user_id"
     t.index ["cart_id"], name: "index_cart_items_on_cart_id", using: :btree
     t.index ["mask_id"], name: "index_cart_items_on_mask_id", using: :btree
   end


### PR DESCRIPTION
# what
カート機能が一覧表示にしかなっていなかったため、購入機能にリンクできるよう合計金額及び寄付金額を表示し、購入ボタンも実装。
重複データの一括表示も最終的には行う予定だが、現時点ではカート画面の「変更」「削除」ボタンが対応できておらず、一旦コメントアウトとしている。

# why
カート機能から購入機能までの流れは通販サイトには必須の流れであり、その機能を実装していくために表示を改善した。
https://gyazo.com/da70db06d045dcbdd1ce49d2efb5043f